### PR TITLE
Chore/unify transaction result information

### DIFF
--- a/src/upload/catalog/controller/extension/payment/webpay.php
+++ b/src/upload/catalog/controller/extension/payment/webpay.php
@@ -261,6 +261,19 @@ class ControllerExtensionPaymentWebpay extends Controller {
 
         $config = $this->getConfig();
 
+        if($result['detailOutput']['paymentTypeCode'] == "SI" || $result['detailOutput']['paymentTypeCode'] == "S2" ||
+            $result['detailOutput']['paymentTypeCode'] == "NC" || $result['detailOutput']['paymentTypeCode'] == "VC" ) {
+            $installmentType = $config['VENTA_DESC'][$result['detailOutput']['paymentTypeCode']];
+        } else {
+            $installmentType = "Sin cuotas";
+        }
+
+        if($result['detailOutput']['paymentTypeCode'] == "VD"){
+            $paymentType = "Débito";
+        } else {
+            $paymentType = "Crédito";
+        }
+
         $data['title'] = sprintf($this->language->get('heading_title'), $this->config->get('config_name'));
         $data['heading_title'] = sprintf($this->language->get('heading_title'), $this->config->get('config_name'));
         $data['text_success'] = $this->language->get('text_success');
@@ -274,9 +287,10 @@ class ControllerExtensionPaymentWebpay extends Controller {
         $data['tbk_hora_transaccion'] = $datetime->format('H:i:s');
         $data['tbk_dia_transaccion'] = $datetime->format('d-m-Y');
         $data['tbk_final_numero_tarjeta'] = '************' . $result['cardDetail']['cardNumber'];
-        $data['tbk_tipo_pago'] = $config['VENTA_DESC'][$result['detailOutput']['paymentTypeCode']];
+        $data['tbk_tipo_pago'] = $paymentType;
+        $data['tbk_tipo_cuotas'] = $installmentType;
         $data['tbk_monto'] = $result['detailOutput']['amount'];
-        $data['tbk_tipo_cuotas'] = $result['detailOutput']['sharesNumber'];
+        $data['tbk_numero_cuotas'] = $result['detailOutput']['sharesNumber'];
 
         $this->session->data['transbank_webpay_result'] = $this->load->view('extension/payment/webpay_success', $data);
         $this->response->redirect($this->url->link('checkout/success', 'language=' . $this->config->get('config_language'), 'SSL'));

--- a/src/upload/catalog/view/theme/default/template/extension/payment/webpay_success.twig
+++ b/src/upload/catalog/view/theme/default/template/extension/payment/webpay_success.twig
@@ -33,16 +33,20 @@
                     <td>{{ tbk_final_numero_tarjeta  }}</td>
                 </tr>
                 <tr>
-                    <td>Tipo de Pago:</td>
-                    <td>{{ tbk_tipo_pago  }}</td>
-                </tr>
-                <tr>
                     <td>Monto Compra:</td>
                     <td>{{ tbk_monto  }}</td>
                 </tr>
                 <tr>
+                    <td>Tipo de Pago:</td>
+                    <td>{{ tbk_tipo_pago  }}</td>
+                </tr>
+                <tr>
+                    <td>Tipo de Cuotas:</td>
+                    <td>{{ tbk_tipo_cuotas }}</td>
+                </tr>
+                <tr>
                     <td>Número de Cuotas:</td>
-                    <td>{{ tbk_tipo_cuotas  }}</td>
+                    <td>{{ tbk_numero_cuotas }}</td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
Across all plugins the information being shown wasn't the same.

Now the information shown in the transaction success information screen is the same for all plugins.

Disclaimer: The order of the information shown might not be the same

