### PR TITLE
feat/add-telemetry

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #Script for configure the plugin project
-PHP_SDK_VERSION="1.6.0"
+PHP_SDK_VERSION="1.6.1"
 REPO_SDK="https://github.com/TransbankDevelopers/transbank-sdk-php/archive/$PHP_SDK_VERSION.zip"
 DIR_LIBS="src/upload/system/library"
 DIR_NAME_SDK="transbank-sdk-php"

--- a/config.sh
+++ b/config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #Script for configure the plugin project
-PHP_SDK_VERSION="1.5.1"
+PHP_SDK_VERSION="1.6.0"
 REPO_SDK="https://github.com/TransbankDevelopers/transbank-sdk-php/archive/$PHP_SDK_VERSION.zip"
 DIR_LIBS="src/upload/system/library"
 DIR_NAME_SDK="transbank-sdk-php"

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+./config.sh
 #Script for create the plugin artifact
 echo "Travis tag: $TRAVIS_TAG"
 

--- a/src/upload/admin/controller/extension/payment/webpay.php
+++ b/src/upload/admin/controller/extension/payment/webpay.php
@@ -84,13 +84,33 @@ WnWrkcr2qakpHzERn8irKBPhvlifW5sdMH4tz/4SLVwkek24Sp8CVmIIgQR3nyR9
         foreach ($redirs as $value) {
             $this->request->post['payment_webpay_url_'.$value] = HTTP_CATALOG . 'index.php?route=extension/payment/webpay/' .$value;
         }
+    
+        $args = $this->getPluginArgs();
+    
+        $_SESSION["config"] = $args;
+        $hc = new HealthCheck($args);
+        $healthcheck = json_decode($hc->printFullResume(), true);
 
         // validacion de modificaciones
 
         if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validate()) {
             $this->model_setting_setting->editSetting('payment_webpay', $this->request->post);
 
+            
             $this->session->data['success'] = $this->language->get('text_success');
+            
+            $requestData = $this->request->post;
+            if($requestData['payment_webpay_test_mode'] === "PRODUCCION"){
+                $telemetryData = $hc->getPluginInfo($hc->ecommerce);
+    
+                $response = (new PluginVersion())->registerVersion(
+                    $requestData['payment_webpay_commerce_code'],
+                    $telemetryData['current_plugin_version'],
+                    $telemetryData['ecommerce_version'],
+                    PluginVersion::ECOMMERCE_OPENCART
+                );
+        
+            }
 
             $this->response->redirect($this->url->link('extension/payment/webpay', 'user_token=' .$this->session->data['user_token'] . '&type=payment', true));
         }
@@ -177,50 +197,7 @@ WnWrkcr2qakpHzERn8irKBPhvlifW5sdMH4tz/4SLVwkek24Sp8CVmIIgQR3nyR9
         $data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
         $this->load->model('localisation/geo_zone');
         $data['geo_zones'] = $this->model_localisation_geo_zone->getGeoZones();
-
-        // si desde la instalacion inicial no toma los parametros por defecto
-
-        $args = array(
-            'MODO' => $this->default_config['test_mode'],
-            'COMMERCE_CODE' => $this->default_config['commerce_code'],
-            'PRIVATE_KEY' => $this->default_config['private_key'],
-            'PUBLIC_CERT' => $this->default_config['public_cert'],
-            'ECOMMERCE' => 'opencart'
-        );
-
-        if (isset($this->request->post['payment_webpay_commerce_code'])) {
-            $args = array(
-                'MODO' => $this->request->post['payment_webpay_test_mode'],
-                'COMMERCE_CODE' => $this->request->post['payment_webpay_commerce_code'],
-                'PRIVATE_KEY' => $this->request->post['payment_webpay_private_key'],
-                'PUBLIC_CERT' => $this->request->post['payment_webpay_public_cert'],
-                'ECOMMERCE' => 'opencart'
-            );
-        } else if ($this->config->get('payment_webpay_commerce_code')) {
-            $args = array(
-                'MODO' => $this->config->get('payment_webpay_test_mode'),
-                'COMMERCE_CODE' => $this->config->get('payment_webpay_commerce_code'),
-                'PRIVATE_KEY' => $this->config->get('payment_webpay_private_key'),
-                'PUBLIC_CERT' => $this->config->get('payment_webpay_public_cert'),
-                'ECOMMERCE' => 'opencart'
-            );
-        }
-
-        $_SESSION["config"] = $args;
-
-        $hc = new HealthCheck($args);
-        $healthcheck = json_decode($hc->printFullResume(), true);
-
-        if($args['MODO'] === "PRODUCCION"){
-            $telemetryData = $hc->getPluginInfo($hc->ecommerce);
-
-            (new PluginVersion())->registerVersion(
-                $args['COMMERCE_CODE'],
-                $telemetryData['current_plugin_version'],
-                $telemetryData['ecommerce_version'],
-                PluginVersion::ECOMMERCE_OPENCART
-            );
-        }
+        
 
         $lh = new LogHandler();
         $loghandler = json_decode($lh->getResume(), true);
@@ -279,5 +256,38 @@ WnWrkcr2qakpHzERn8irKBPhvlifW5sdMH4tz/4SLVwkek24Sp8CVmIIgQR3nyR9
         }
 
         return !$this->error;
+    }
+    /**
+     * @return array
+     */
+    public function getPluginArgs()
+    {
+        $args = [
+            'MODO' => $this->default_config['test_mode'],
+            'COMMERCE_CODE' => $this->default_config['commerce_code'],
+            'PRIVATE_KEY' => $this->default_config['private_key'],
+            'PUBLIC_CERT' => $this->default_config['public_cert'],
+            'ECOMMERCE' => 'opencart'
+        ];
+        
+        if (isset($this->request->post['payment_webpay_commerce_code'])) {
+            $args = [
+                'MODO' => $this->request->post['payment_webpay_test_mode'],
+                'COMMERCE_CODE' => $this->request->post['payment_webpay_commerce_code'],
+                'PRIVATE_KEY' => $this->request->post['payment_webpay_private_key'],
+                'PUBLIC_CERT' => $this->request->post['payment_webpay_public_cert'],
+                'ECOMMERCE' => 'opencart'
+            ];
+        } else if ($this->config->get('payment_webpay_commerce_code')) {
+            $args = [
+                'MODO' => $this->config->get('payment_webpay_test_mode'),
+                'COMMERCE_CODE' => $this->config->get('payment_webpay_commerce_code'),
+                'PRIVATE_KEY' => $this->config->get('payment_webpay_private_key'),
+                'PUBLIC_CERT' => $this->config->get('payment_webpay_public_cert'),
+                'ECOMMERCE' => 'opencart'
+            ];
+        }
+        
+        return $args;
     }
 }

--- a/src/upload/admin/controller/extension/payment/webpay.php
+++ b/src/upload/admin/controller/extension/payment/webpay.php
@@ -2,6 +2,7 @@
 
 require_once(DIR_CATALOG.'controller/extension/payment/libwebpay/HealthCheck.php');
 require_once(DIR_CATALOG.'controller/extension/payment/libwebpay/LogHandler.php');
+require_once(DIR_CATALOG.'controller/extension/payment/libwebpay/telemetry/PluginVersion.php');
 
 class ControllerExtensionPaymentWebpay extends Controller {
 
@@ -209,6 +210,17 @@ WnWrkcr2qakpHzERn8irKBPhvlifW5sdMH4tz/4SLVwkek24Sp8CVmIIgQR3nyR9
 
         $hc = new HealthCheck($args);
         $healthcheck = json_decode($hc->printFullResume(), true);
+
+        if($args['MODO'] === "PRODUCCION"){
+            $telemetryData = $hc->getPluginInfo($hc->ecommerce);
+
+            (new PluginVersion())->registerVersion(
+                $args['COMMERCE_CODE'],
+                $telemetryData['current_plugin_version'],
+                $telemetryData['ecommerce_version'],
+                PluginVersion::ECOMMERCE_OPENCART
+            );
+        }
 
         $lh = new LogHandler();
         $loghandler = json_decode($lh->getResume(), true);

--- a/src/upload/catalog/controller/extension/payment/libwebpay/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay/HealthCheck.php
@@ -149,7 +149,7 @@ class HealthCheck {
 
     // creacion de retornos
     // arma array que entrega informacion del ecommerce: nombre, version instalada, ultima version disponible
-    private function getPluginInfo($ecommerce){
+    public function getPluginInfo($ecommerce){
         $data = $this->getEcommerceInfo($ecommerce);
         $result = array(
             'ecommerce' => $ecommerce,

--- a/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
@@ -13,7 +13,7 @@ class PluginVersion
     const ECOMMERCE_PRESTASHOP = 2;
     const ECOMMERCE_MAGENTO2 = 3;
     const ECOMMERCE_VIRTUEMART = 4;
-    const ECOMMERCE_OPENCART = 2;
+    const ECOMMERCE_OPENCART = 5;
     const ECOMMERCE_SDK = 6;
     /**
      * PluginVersion constructor.

--- a/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
@@ -7,13 +7,13 @@ class PluginVersion
 
     const ENV_INTEGRATION = 'INTEGRACION';
     const ENV_PRODUCTION = 'PRODUCCION';
-    const PRODUCT_WEBPAY = 5;
+    const PRODUCT_WEBPAY = 1;
 
     const ECOMMERCE_WOOCOMMERCE = 1;
     const ECOMMERCE_PRESTASHOP = 2;
     const ECOMMERCE_MAGENTO2 = 3;
     const ECOMMERCE_VIRTUEMART = 4;
-    const ECOMMERCE_OPENCART = 5;
+    const ECOMMERCE_OPENCART = 2;
     const ECOMMERCE_SDK = 6;
     /**
      * PluginVersion constructor.

--- a/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay/telemetry/PluginVersion.php
@@ -1,0 +1,34 @@
+<?php
+
+class PluginVersion
+{
+    protected $soapUri = 'http://www.cumbregroup.com/tbk-webservice/PluginVersion.php?wsdl';
+    protected $client;
+
+    const ENV_INTEGRATION = 'INTEGRACION';
+    const ENV_PRODUCTION = 'PRODUCCION';
+    const PRODUCT_WEBPAY = 5;
+
+    const ECOMMERCE_WOOCOMMERCE = 1;
+    const ECOMMERCE_PRESTASHOP = 2;
+    const ECOMMERCE_MAGENTO2 = 3;
+    const ECOMMERCE_VIRTUEMART = 4;
+    const ECOMMERCE_OPENCART = 5;
+    const ECOMMERCE_SDK = 6;
+    /**
+     * PluginVersion constructor.
+    */
+    public function __construct()
+    {
+        $this->client = new \SoapClient($this->soapUri);
+    }
+
+    public function registerVersion($commerceCode, $pluginVersion, $ecommerceVersion, $ecommerceId, $environment = self::ENV_PRODUCTION, $product = self::PRODUCT_WEBPAY)
+    {
+        try {
+            return $this->client->version_register($commerceCode, $pluginVersion, $ecommerceVersion, $ecommerceId, $environment, $product);
+        } catch (\Exception $e) {
+            // Si la conexión falla, simplemente no hacer nada.
+        }
+    }
+}

--- a/src/upload/system/library/TransbankSdkWebpay.php
+++ b/src/upload/system/library/TransbankSdkWebpay.php
@@ -7,7 +7,7 @@ use Transbank\Webpay\Webpay;
 
 class TransbankSdkWebpay {
 
-    const PLUGIN_VERSION = '2.1.4'; //version of plugin payment
+    const PLUGIN_VERSION = '1.0.0'; //version of plugin payment
 
     var $transaction;
 


### PR DESCRIPTION
When the user updates the settings page of the plugin, if the environment
is set to PRODUCCION, then the plugins sends the plugin version, the
opencard version and the commerce code to a internal telemetry API